### PR TITLE
Add scale down wait time to prevent scaling down between small waits

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,5 +4,6 @@ node_chrome_max_scale_limit=2
 node_chrome_min_scale_limit=1
 k8s_token=<Kubernetes API Bearer Token>
 grid_scale_check_frequency_in_sec=10
+grid_scale_down_wait_time_in_sec=600
 grid_daily_cleanup_cron=0 10 10 * * ?
 logging_level_com_sahajamit_k8s=INFO


### PR DESCRIPTION
- Add a default wait of 600 seconds before scaling down. This is to prevent unwanted scale downs during the end of tests.